### PR TITLE
Add missing dependency requires

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ## MAC OS
 .DS_Store
 dist
+
 ## TEXTMATE
 *.tmproj
 tmtags
@@ -13,10 +14,14 @@ tmtags
 ## VIM
 *.swp
 
+## RUBYMINE
+.idea
+
 ## PROJECT::GENERAL
 coverage
 rdoc
 pkg
+Gemfile.lock
 
 ## PROJECT::SPECIFIC
 dist/*

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,13 @@
-require "mg"
-require 'shoulda/tasks'
+require 'mg'
+require 'rake/testtask'
+require 'shoulda/context/tasks'
 
-MG.new("chargify.gemspec")
+MG.new('chargify.gemspec')
 
-desc 'Run tests'
-task :test do
-  sh 'testrb -I.:lib test/*_test.rb'
+Rake::TestTask.new do |t|
+  t.libs << 'test'
+  t.test_files = FileList['test/*_test.rb']
+  t.verbose = true
 end
 
 task :default => :test

--- a/chargify.gemspec
+++ b/chargify.gemspec
@@ -1,10 +1,10 @@
 # -*- encoding: utf-8 -*-
 
-# require File.dirname(__FILE__) + '/lib/chargify.rb'
+require File.dirname(__FILE__) + '/lib/chargify/version.rb'
 
 Gem::Specification.new do |s|
   s.name = %q{chargify}
-  s.version = "0.3.0"
+  s.version = Chargify::VERSION.dup
   s.authors = ["Wynn Netherland", "Nash Kabbara"]
   s.email = %q{wynn.netherland@gmail.com}
   s.homepage = %q{http://github.com/pengwynn/chargify}
@@ -18,12 +18,14 @@ Gem::Specification.new do |s|
     Dir.glob(['{lib,test}/**/*.rb', 'test/fixtures/*.json'])
   s.test_files = [ "test/helper.rb", "test/chargify_test.rb" ]
 
-  s.add_runtime_dependency(%q<hashie>, [">= 1.0.0"])
+  s.add_runtime_dependency(%q<crack>, ['>= 0.3.0'])
+  s.add_runtime_dependency(%q<hashie>, ['>= 1.0.0', '< 2.1.0'])
   s.add_runtime_dependency(%q<httparty>, [">= 0.7.4"])
   s.add_development_dependency(%q<shoulda>, [">= 2.10.1"])
   s.add_development_dependency(%q<jnunemaker-matchy>, ["= 0.4.0"])
   s.add_development_dependency(%q<mocha>, ["~> 0.9.8"])
   s.add_development_dependency(%q<fakeweb>, [">= 1.2.5"])
   s.add_development_dependency('mg', ['>= 0.0.8'])
+  s.add_development_dependency('rake', ['>= 10.4.2'])
   s.add_development_dependency('test-unit', ['>= 2.3.0'])
 end

--- a/chargify.gemspec
+++ b/chargify.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
     Dir.glob(['{lib,test}/**/*.rb', 'test/fixtures/*.json'])
   s.test_files = [ "test/helper.rb", "test/chargify_test.rb" ]
 
-  s.add_runtime_dependency(%q<crack>, ['>= 0.3.0'])
   s.add_runtime_dependency(%q<hashie>, ['>= 1.0.0', '< 2.1.0'])
   s.add_runtime_dependency(%q<httparty>, [">= 0.7.4"])
   s.add_development_dependency(%q<shoulda>, [">= 2.10.1"])

--- a/lib/chargify.rb
+++ b/lib/chargify.rb
@@ -1,12 +1,9 @@
 require 'hashie'
 require 'httparty'
+require 'chargify/version'
 
 directory = File.expand_path(File.dirname(__FILE__))
 
 Hash.send :include, Hashie::HashExtensions
 
 require File.join(directory, 'chargify', 'client')
-
-module Chargify
-  VERSION = "0.3.0".freeze
-end

--- a/lib/chargify/client.rb
+++ b/lib/chargify/client.rb
@@ -1,3 +1,5 @@
+require 'crack'
+
 module Chargify
   class << self
      attr_accessor :subdomain, :api_key, :shared_key, :site#, :format, :timeout, :shared_key

--- a/lib/chargify/client.rb
+++ b/lib/chargify/client.rb
@@ -1,5 +1,3 @@
-require 'crack'
-
 module Chargify
   class << self
      attr_accessor :subdomain, :api_key, :shared_key, :site#, :format, :timeout, :shared_key
@@ -29,10 +27,12 @@ module Chargify
   
   class Parser < HTTParty::Parser
     def parse
+      return {} if body.strip.empty?
+
       begin
-        Crack::JSON.parse(body) || {}
-      rescue => e
-        raise UnexpectedResponseError, "Crack could not parse JSON. It said: #{e.message}. Chargify's raw response: #{body}"
+        ::JSON.parse(body) || {}
+      rescue JSON::ParserError => e
+        raise UnexpectedResponseError, "Could not parse JSON: #{e.message}. Chargify's raw response: #{body}"
       end
     end
   end

--- a/lib/chargify/version.rb
+++ b/lib/chargify/version.rb
@@ -1,0 +1,3 @@
+module Chargify
+  VERSION = '0.3.0'.freeze
+end

--- a/test/chargify_test.rb
+++ b/test/chargify_test.rb
@@ -1,4 +1,4 @@
-require 'test/helper'
+require 'helper'
 
 class ChargifyTest < Test::Unit::TestCase
   context "Chargify API client" do
@@ -53,7 +53,7 @@ class ChargifyTest < Test::Unit::TestCase
         :last_name    => "Netherland",
         :email        => "wynn@example.com"
       }
-      customer = @client.update_customer(info)
+      customer = @client.update_customer(info.delete(:id), info)
       customer.first_name.should == "Wynn"
     end
     


### PR DESCRIPTION
@kapost/core This adds some missing `require`s that are needed.  I believe these were being implicitly required via hashie previously, but a change in versions resulted in dependencies we need no longer being available.  I've also fixed some issues around running the tests, and fixed a test from a previous change to `Client#update_customer`.
